### PR TITLE
PDCL-9790 Use TextDecoder for saving the response. It allows handling larger responses.

### DIFF
--- a/src/lib/actions/sendData.js
+++ b/src/lib/actions/sendData.js
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const byteArrayToString = (buf) => {
-  return String.fromCharCode.apply(null, new Uint8Array(buf));
-};
+const byteArrayToString = (buf) =>
+  new TextDecoder('utf-8').decode(new Uint8Array(buf));
 
 module.exports = ({
   arc: { ruleStash = {} },


### PR DESCRIPTION
## Description

The previous method used for decoding an array buffer was triggering a stack overflow for responses larger than 5kb.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-9790

## Motivation and Context

Similar issue with https://github.com/adobe/reactor-turbine-edge/pull/9

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have made any necessary test changes and all tests pass.
