### PR TITLE
PDCL-9827 Do not allow body to be sent for GET and HEAD requests.

### DIFF
--- a/src/view/actions/__tests__/sendData.test.jsx
+++ b/src/view/actions/__tests__/sendData.test.jsx
@@ -45,7 +45,7 @@ const getFromFields = () => ({
   headersTab: screen.getByText(/headers/i, {
     selector: 'div[role="tablist"] span'
   }),
-  bodyTab: screen.getByText(/^body$/i, {
+  bodyTab: screen.queryByText(/^body$/i, {
     selector: 'div[role="tablist"] span'
   }),
   bodyRawInput: screen.queryByLabelText('Body (Raw)'),
@@ -125,6 +125,7 @@ describe('Send data view', () => {
     await act(async () => {
       extensionBridge.init({
         settings: {
+          method: 'POST',
           body: '{"e":"f"}'
         }
       });
@@ -221,6 +222,7 @@ describe('Send data view', () => {
     await act(async () => {
       extensionBridge.init({
         settings: {
+          method: 'POST',
           body: '{"e":"f"}'
         }
       });
@@ -233,7 +235,7 @@ describe('Send data view', () => {
     await changeInputValue(bodyRawInput, '{{"ee":"ff"}');
 
     expect(extensionBridge.getSettings()).toEqual({
-      method: 'GET',
+      method: 'POST',
       url: '',
       body: { ee: 'ff' }
     });
@@ -491,7 +493,7 @@ describe('Send data view', () => {
       await act(async () => {
         extensionBridge.init({
           settings: {
-            method: 'GET',
+            method: 'POST',
             url: '',
             body: {
               a: 'b'
@@ -516,7 +518,7 @@ describe('Send data view', () => {
       await changeInputValue(valueInput, 'd');
 
       expect(extensionBridge.getSettings()).toEqual({
-        method: 'GET',
+        method: 'POST',
         url: '',
         body: {
           a: 'b',
@@ -531,7 +533,7 @@ describe('Send data view', () => {
       await act(async () => {
         extensionBridge.init({
           settings: {
-            method: 'GET',
+            method: 'POST',
             url: '',
             body: {
               a: 'b',
@@ -551,7 +553,7 @@ describe('Send data view', () => {
       await click(deleteButton);
 
       expect(extensionBridge.getSettings()).toEqual({
-        method: 'GET',
+        method: 'POST',
         url: '',
         body: {
           a: 'b'
@@ -565,7 +567,7 @@ describe('Send data view', () => {
       await act(async () => {
         extensionBridge.init({
           settings: {
-            method: 'GET',
+            method: 'POST',
             url: '',
             body: {
               a: 'b',
@@ -582,7 +584,7 @@ describe('Send data view', () => {
       await click(bodyJsonCheckbox);
 
       expect(extensionBridge.getSettings()).toEqual({
-        method: 'GET',
+        method: 'POST',
         url: '',
         body: { a: 'b', c: 'd' }
       });
@@ -594,7 +596,7 @@ describe('Send data view', () => {
       await act(async () => {
         extensionBridge.init({
           settings: {
-            method: 'GET',
+            method: 'POST',
             url: '',
             body: '{a:"b",c:"d"}a'
           }
@@ -608,7 +610,7 @@ describe('Send data view', () => {
       await click(bodyJsonCheckbox);
 
       expect(extensionBridge.getSettings()).toEqual({
-        method: 'GET',
+        method: 'POST',
         url: ''
       });
 
@@ -616,10 +618,32 @@ describe('Send data view', () => {
       await click(bodyRawCheckbox);
 
       expect(extensionBridge.getSettings()).toEqual({
-        method: 'GET',
+        method: 'POST',
         url: '',
         body: '{a:"b",c:"d"}a'
       });
+    });
+
+    test('is not visible for GET requests', async () => {
+      renderView(SendData);
+
+      await act(async () => {
+        extensionBridge.init({
+          settings: {
+            method: 'POST',
+            url: '',
+            body: '{a:"b",c:"d"}'
+          }
+        });
+      });
+
+      let { bodyTab, methodSelect } = getFromFields();
+      await click(bodyTab);
+
+      await changePickerValue(methodSelect, 'GET');
+
+      ({ bodyTab } = getFromFields());
+      expect(bodyTab).toBeNull();
     });
   });
 });

--- a/src/view/actions/components/bodySection/getSettings.js
+++ b/src/view/actions/components/bodySection/getSettings.js
@@ -11,8 +11,9 @@ governing permissions and limitations under the License.
 */
 
 import { addToEntityFromVariables } from '../../../utils/entityVariablesConverter';
+import requestMethodHelper from '../requestSection/requestMethodHelper';
 
-export default ({ bodyType, bodyRaw, bodyJsonPairs }) => {
+export default ({ method, bodyType, bodyRaw, bodyJsonPairs }) => {
   let body;
   const settings = {};
 
@@ -33,7 +34,7 @@ export default ({ bodyType, bodyRaw, bodyJsonPairs }) => {
     }
   }
 
-  if (body) {
+  if (body && requestMethodHelper.showBodyTab(method)) {
     settings.body = body;
   }
 

--- a/src/view/actions/components/requestSection/fields.jsx
+++ b/src/view/actions/components/requestSection/fields.jsx
@@ -30,7 +30,7 @@ const parseQueryParams = (setValue, v) => {
   });
 };
 
-export default function RequestSectionFields() {
+export default function RequestSectionFields({ onMethodUpdate }) {
   const { setValue, control } = useFormContext();
 
   return (
@@ -71,7 +71,10 @@ export default function RequestSectionFields() {
                   name: 'DELETE'
                 }
               ]}
-              onSelectionChange={onChange}
+              onSelectionChange={(v) => {
+                onChange(v);
+                onMethodUpdate(v);
+              }}
               onBlur={onBlur}
             >
               {(item) => <Item>{item.name}</Item>}

--- a/src/view/actions/components/requestSection/requestMethodHelper.js
+++ b/src/view/actions/components/requestSection/requestMethodHelper.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const METHOD_CONSTANTS = {
+  NO_BODY_METHODS: ['GET', 'HEAD'],
+  DEFAULT_METHOD: 'GET'
+};
+
+export default {
+  ...METHOD_CONSTANTS,
+  showBodyTab: (v) => !METHOD_CONSTANTS.NO_BODY_METHODS.includes(v)
+};

--- a/src/view/actions/sendData.jsx
+++ b/src/view/actions/sendData.jsx
@@ -14,6 +14,7 @@ import React, { useState } from 'react';
 import { Item, View, TabList, TabPanels, Tabs } from '@adobe/react-spectrum';
 
 import ExtensionView from '../components/extensionView';
+import requestMethodHelper from './components/requestSection/requestMethodHelper';
 
 import RequestsFields from './components/requestSection/fields';
 import getRequestFieldsInitValues from './components/requestSection/getInitValues';
@@ -40,8 +41,10 @@ import getAdvancedValues from './components/advancedSection/getInitValues';
 import getAdvancedSettings from './components/advancedSection/getSettings';
 import validateAdvancedFields from './components/advancedSection/validate';
 
+const DEFAULT_TAB = 'queryParams';
+
 export default function SendData() {
-  const [selectedTab, setSelectedTab] = useState('queryParams');
+  const [selectedTab, setSelectedTab] = useState(DEFAULT_TAB);
 
   return (
     <ExtensionView
@@ -66,9 +69,13 @@ export default function SendData() {
         ...validateBodyFields(values),
         ...validateAdvancedFields(values)
       })}
-      render={() => (
+      render={({ method }) => (
         <>
-          <RequestsFields />
+          <RequestsFields
+            onMethodUpdate={(v) =>
+              requestMethodHelper.showBodyTab(v) || setSelectedTab(DEFAULT_TAB)
+            }
+          />
 
           <Tabs
             selectedKey={selectedTab}
@@ -78,7 +85,9 @@ export default function SendData() {
             <TabList>
               <Item key="queryParams">Query Parameters</Item>
               <Item key="headers">Headers</Item>
-              <Item key="body">Body</Item>
+              {requestMethodHelper.showBodyTab(method) && (
+                <Item key="body">Body</Item>
+              )}
             </TabList>
             <TabPanels>
               <Item key="queryParams">

--- a/src/view/components/extensionView.jsx
+++ b/src/view/components/extensionView.jsx
@@ -65,7 +65,7 @@ const ExtensionView = function ExtensionView({
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...methods}
         >
-          <form>{render()}</form>
+          <form>{render(methods.watch())}</form>
           {/* <DisplayFormState /> */}
         </FormProvider>
       </ErrorBoundary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fetch API throws an error when body is being sent for GET and HEAD requests. Error shown:

`Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body.`

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-9827


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have made any necessary test changes and all tests pass.
